### PR TITLE
Added option to use remote OVA instead

### DIFF
--- a/Deploy-FAH/FAH_appliance/main.tf
+++ b/Deploy-FAH/FAH_appliance/main.tf
@@ -31,8 +31,9 @@ resource "vsphere_virtual_machine" "vm" {
   host_system_id = "${data.vsphere_host.host.id}"
 
   ovf_deploy {
-	// Path to local ovf/ova file
+	// Path to local ovf/ova file comment this line, and uncomment the next, to use remote OVA instead.
 	local_ovf_path = "${var.ova_location}"
+  //remote_ovf_url = "https://download3.vmware.com/software/vmw-tools/VMWare_Folding@Home_Appliance/VMware-Appliance-FaH_1.0.4.ova"
    disk_provisioning    = "thin"
    ovf_network_map = {
         "VM Network" = data.vsphere_network.network.id

--- a/Deploy-FAH/terraform.tfvars
+++ b/Deploy-FAH/terraform.tfvars
@@ -31,5 +31,5 @@ vsphere_resource_pool = "folding@home"
 // Name of VM folder to be created. E.g "FAH-VMs"
 vsphere_vm_folder = "folding@home"
 
-//Location of OVA file
+//Location of OVA file - Change Deploy-FAH/FAH_appliance/main.tf to use remote OVA instead. 
 ova_location = "/home/ubuntu/Deploy-FAH/VMware-Appliance-FaH_1.0.4.ova"


### PR DESCRIPTION
For me, to have the OVA local, don't make sense, so I added the option, to use remote OVA as well.
The url is static, and there os probably a more pretty way, to implement this, but this is working, and won't break the way you do it today. So I thought it was a nice option, for a cool project. 